### PR TITLE
Merge lines and remove comments before parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cmacros"
 description = "Functions for parsing #define macros from C headers and translating them to Rust code"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Robert Knight <robertknight@gmail.com>", "Alexey Gerasev <alexey.gerasev@gmail.com>"]
 repository = "https://github.com/nthend/rust-cmacros"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cmacros"
 description = "Functions for parsing #define macros from C headers and translating them to Rust code"
 version = "0.1.1"
 authors = ["Robert Knight <robertknight@gmail.com>", "Alexey Gerasev <alexey.gerasev@gmail.com>"]
-repository = "https://github.com/nthend/rust-cmacros"
+repository = "https://github.com/robertknight/rust-cmacros"
 readme = "README.md"
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,19 @@
 name = "cmacros"
 description = "Functions for parsing #define macros from C headers and translating them to Rust code"
 version = "0.1.0"
-authors = ["Robert Knight <robertknight@gmail.com>"]
-repository = "https://github.com/robertknight/rust-cmacros"
+authors = ["Robert Knight <robertknight@gmail.com>", "Alexey Gerasev <alexey.gerasev@gmail.com>"]
+repository = "https://github.com/nthend/rust-cmacros"
 readme = "README.md"
 license = "MIT"
 
-[dependencies]
+[dev_dependencies]
 walker="^1.0.0"
 argparse="^0.2.0"
+
+[[example]]
+name = "parse_all_headers"
+path = "examples/parse_all_headers.rs"
+
+[[example]]
+name = "translate_macros"
+path = "examples/translate_macros.rs"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rust-cmacros
-[![Build Status](https://travis-ci.org/nthend/rust-cmacros.png?branch=master)](https://travis-ci.org/nthend/rust-cmacros)
+[![Build Status](https://travis-ci.org/robertknight/rust-cmacros.png?branch=master)](https://travis-ci.org/robertknight/rust-cmacros)
 
 Rust library to assist with parsing and translating #define
 macro definitions from C header files

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rust-cmacros
-[![Build Status](https://travis-ci.org/robertknight/rust-cmacros.png?branch=master)](https://travis-ci.org/robertknight/rust-cmacros)
+[![Build Status](https://travis-ci.org/nthend/rust-cmacros.png?branch=master)](https://travis-ci.org/nthend/rust-cmacros)
 
 Rust library to assist with parsing and translating #define
 macro definitions from C header files

--- a/examples/parse_all_headers.rs
+++ b/examples/parse_all_headers.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::{Read};
 use std::path::{Path};
 use walker::Walker;
 
@@ -60,7 +60,7 @@ fn main() {
                 for cmacro in macros {
                     let mut def = format!("#define {}", cmacro.name);
                     match cmacro.args {
-                        Some(args) => def.push_str(&format!("({})", &args.connect(","))),
+                        Some(args) => def.push_str(&format!("({})", &args.join(","))),
                         None => ()
                     }
                     match cmacro.body {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ where TranslateFn: Fn(&CMacro) -> TranslateAction {
             }
         })
         .collect();
-    decl_lines.connect("\n")
+    decl_lines.join("\n")
 }
 
 impl CMacro {
@@ -373,5 +373,5 @@ fn test_generate_rust_src() {
     assert_eq!(src, vec![
         "pub const USED_CONST: i32 = 1;",
         "pub const USED_CONST_2: i32 = 2;"
-    ].connect("\n"))
+    ].join("\n"))
 }


### PR DESCRIPTION
I've added some C-preprocessor-like steps before parsing:
+ merge lines with `\` symbol at the end,
+ remove single- and multi-line C comments.

These steps simplify the parsing process, but the algorithm is not in-place anymore because it stores intermediate results.

Also i've fixed some warnings and test error, and moved `walker` and `argparse` to `dev_dependencies` because there's no need to download and compile them if you don't want to run examples.